### PR TITLE
Extracts Christianson's two-phases algorithm from two_phase_solver

### DIFF
--- a/fax/implicit/twophase.py
+++ b/fax/implicit/twophase.py
@@ -9,59 +9,41 @@ from fax import loop
 logger = logging.getLogger(__name__)
 
 
-def two_phase_solver(param_func, forward_solver=None, default_rtol=1e-4,
-                     default_atol=1e-4, default_max_iter=5000,
-                     default_batched_iter_size=1):
-    """
+def make_forward_fixed_point_iteration(
+        param_func, default_rtol=1e-4, default_atol=1e-4, default_max_iter=5000,
+        default_batched_iter_size=1):
+    def _default_solver(init_x, params):
+        rtol, atol = converge.adjust_tol_for_dtype(default_rtol,
+                                                   default_atol,
+                                                   init_x.dtype)
 
-    Args:
-        param_func: A "parametric" operator (i.e., callable) taking in some
-            parameters and returning a function for which we seek a fixed point.
-        forward_solver:
-        default_rtol:
-        default_atol:
-        default_max_iter:
-        default_batched_iter_size:
+        def convergence_test(x_new, x_old):
+            return converge.max_diff_test(x_new, x_old, rtol, atol)
 
-    Returns:
+        func = param_func(params)
+        sol = loop.fixed_point_iteration(
+            init_x=init_x,
+            func=func,
+            convergence_test=convergence_test,
+            max_iter=default_max_iter,
+            batched_iter_size=default_batched_iter_size,
+        )
 
-    """
-    # if no solver is specified, create a default solver
-    if forward_solver is None:
-        def default_solver(init_x, params):
-            rtol, atol = converge.adjust_tol_for_dtype(default_rtol,
-                                                       default_atol,
-                                                       init_x.dtype)
+        return sol
+    return _default_solver
 
-            def convergence_test(x_new, x_old):
-                return converge.max_diff_test(x_new, x_old, rtol, atol)
 
-            func = param_func(params)
-            sol = loop.fixed_point_iteration(
-                init_x=init_x,
-                func=func,
-                convergence_test=convergence_test,
-                max_iter=default_max_iter,
-                batched_iter_size=default_batched_iter_size,
-            )
-
-            return sol
-
-        forward_solver = default_solver
+def make_adjoint_fixed_point_iteration(
+        param_func, default_rtol=1e-4, default_atol=1e-4, default_max_iter=5000,
+        default_batched_iter_size=1):
 
     # define a flat function to fit the vjp API
     def flat_func(i, x, params):
         return param_func(params)(i, x)
 
-    @jax.custom_transforms
-    def two_phase_op(init_xs, params):
-        return forward_solver(init_xs, params)
-
-    def two_phase_vjp(g, ans, init_xs, params):
-        dvalue, dconverged, diter, dprev_value = g
-        # these tensors are returned only for monitoring and have no
-        # defined gradient
-        del dconverged, diter, dprev_value, init_xs
+    def _adjoint_iteration_vjp(g, ans, init_xs, params):
+        dvalue = g
+        del init_xs
         init_dxs = dvalue
 
         fp_vjp_fn = jax.vjp(partial(flat_func, ans.iterations),
@@ -86,7 +68,47 @@ def two_phase_solver(param_func, forward_solver=None, default_rtol=1e-4,
             batched_iter_size=default_batched_iter_size,
         )
 
-        return fp_vjp_fn(dsol.value)[1]
+        return fp_vjp_fn(dsol.value)[1], dsol
+
+    return _adjoint_iteration_vjp
+
+
+def two_phase_solver(param_func, forward_solver=None, default_rtol=1e-4,
+                     default_atol=1e-4, default_max_iter=5000,
+                     default_batched_iter_size=1):
+    """
+
+    Args:
+        param_func: A "parametric" operator (i.e., callable) taking in some
+            parameters and returning a function for which we seek a fixed point.
+        forward_solver:
+        default_rtol:
+        default_atol:
+        default_max_iter:
+        default_batched_iter_size:
+
+    Returns:
+
+    """
+    # if no solver is specified, create a default solver
+    if forward_solver is None:
+        forward_solver = make_forward_fixed_point_iteration(
+            param_func, default_rtol=default_rtol, default_atol=default_atol,
+            default_max_iter=default_max_iter, default_batched_iter_size=default_batched_iter_size)
+
+    adjoint_iteration_vjp = make_adjoint_fixed_point_iteration(
+        param_func, default_rtol=default_rtol, default_atol=default_atol,
+        default_max_iter=default_max_iter, default_batched_iter_size=default_batched_iter_size)
+
+    @jax.custom_transforms
+    def two_phase_op(init_xs, params):
+        return forward_solver(init_xs, params)
+
+    def two_phase_vjp(g, ans, init_xs, params):
+        dvalue, dconverged, diter, dprev_value = g
+        # these tensors are returned only for monitoring and have no defined gradient
+        del dconverged, diter, dprev_value
+        return adjoint_iteration_vjp(dvalue, ans, init_xs, params)[0]
 
     jax.defvjp(two_phase_op, None, two_phase_vjp)
 


### PR DESCRIPTION
Extracts the VJP implementing Christianson's two-phase algorithm from the definition of the function "two_phase_solver" so as to be able to call the VJP manually if desired.

This commit does not affect the way that two_phase_solver is called. The relevant tests still seem to hold.