### PR TITLE
Change argument order to facilitate unpacking

### DIFF
--- a/fax/lagrangian/cga.py
+++ b/fax/lagrangian/cga.py
@@ -348,7 +348,7 @@ def cga_iteration(init_values, f, g, convergence_test, max_iter, step_size_f,
     )
 
 
-def cga_lagrange_min(lr_func, lagrangian, lr_multipliers=None,
+def cga_lagrange_min(lagrangian, lr_func, lr_multipliers=None,
                      linear_op_solver=None, solve_order='alternating'):
 
     def neg_lagrangian(*args, **kwargs):

--- a/fax/lagrangian/cga_test.py
+++ b/fax/lagrangian/cga_test.py
@@ -314,7 +314,7 @@ class CGATest(jax.test_util.JaxTestCase):
 
         lr = 0.5
         rtol = atol = 1e-6
-        opt_init, opt_update, get_params = cga.cga_lagrange_min(lr, lagrangian)
+        opt_init, opt_update, get_params = cga.cga_lagrange_min(lagrangian, lr)
 
         def convergence_test(x_new, x_old):
             return converge.max_diff_test(x_new, x_old, rtol, atol)


### PR DESCRIPTION
This change breaks the API for `cga_lagrange_min`. The purpose of this change is to make argument unpacking easier by grouping the learning rate parameters together. The required parameter `lagrangian` is now the first argument and `lr_func` is the second. `cga_test.py` has been updated accordingly and the tests pass.